### PR TITLE
Configuration extraction & novel sampling

### DIFF
--- a/src/Dubins3D.jl
+++ b/src/Dubins3D.jl
@@ -8,6 +8,6 @@ module Dubins3D
 include("dubinsmaneuver3d.jl")
 
 export DubinsManeuver2D
-export DubinsManeuver3D, getLowerBound, getUpperBound, compute_sampling
+export DubinsManeuver3D, getLowerBound, getUpperBound, compute_sampling, sample_path, get_configuration
 
 end


### PR DESCRIPTION
Adding novel functionality -- vehicle configuration can be queried at a specific distance along the manuever, new sampling function `sample_path` which samples based on sampling step rather than number of samples (old function `compute_sampling` kept for back-compatibility). Other changes in old implementation such that new and updated functions are used to prevent code duplication.